### PR TITLE
Fix Apns Message

### DIFF
--- a/library/ZendService/Apple/Apns/Message.php
+++ b/library/ZendService/Apple/Apns/Message.php
@@ -274,7 +274,7 @@ class Message
         // don't escape utf8 payloads unless json_encode does not exist.
         if (defined('JSON_UNESCAPED_UNICODE') && function_exists('mb_strlen')) {
             $payload = json_encode($payload, JSON_UNESCAPED_UNICODE);
-            $length = mb_strlen($length, 'UTF-8');
+            $length = mb_strlen($payload, 'UTF-8');
         } else {
             $payload = Json::encode($payload);
             $length = strlen($payload);

--- a/library/ZendService/Apple/Apns/Message/Alert.php
+++ b/library/ZendService/Apple/Apns/Message/Alert.php
@@ -75,7 +75,7 @@ class Alert
             $this->setLocKey($locKey);
         }
         if ($locArgs !== null) {
-            $this->setLocArgs();
+            $this->setLocArgs($locArgs);
         }
         if ($launchImage !== null) {
             $this->setLaunchImage($launchImage);

--- a/tests/ZendService/Apple/Apns/MessageTest.php
+++ b/tests/ZendService/Apple/Apns/MessageTest.php
@@ -117,4 +117,21 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->message->setCustom($data);
         $this->assertEquals($data, $this->message->getCustom());
     }
+
+    public function testAlertConstructor()
+    {
+        $alert = new Alert(
+            'Foo wants to play Bar!',
+            'PLAY',
+            'GAME_PLAY_REQUEST_FORMAT',
+            array('Foo', 'Baz'),
+            'Default.png'
+        );
+
+        $this->assertEquals('Foo wants to play Bar!', $alert->getBody());
+        $this->assertEquals('PLAY', $alert->getActionLocKey());
+        $this->assertEquals('GAME_PLAY_REQUEST_FORMAT', $alert->getLocKey());
+        $this->assertEquals(array('Foo', 'Baz'), $alert->getLocArgs());
+        $this->assertEquals('Default.png', $alert->getLaunchImage());
+    }
 }


### PR DESCRIPTION
Fixed failing unit test due to misnamed variable.
Fixed alert constructor and added in test to a missing setLocArgs.
