### PR TITLE
Update Alert.php

### DIFF
--- a/library/ZendService/Apple/Apns/Message/Alert.php
+++ b/library/ZendService/Apple/Apns/Message/Alert.php
@@ -226,7 +226,7 @@ class Alert
         $alert = array();
         foreach ($vars as $key => $value) {
             if (!is_null($value)) {
-                $key = strtolower(preg_replace('/([a-z])([A-Z])/', '$1_$2', $key));
+                $key = strtolower(preg_replace('/([a-z])([A-Z])/', '$1-$2', $key));
                 $alert[$key] = $value;
             }
         }


### PR DESCRIPTION
Apple servers used "-", not "_" 

'$1_$2' > '$1-$2'

action-loc-key
loc-key
etc.

https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html
