### PR TITLE
Check if Sound Parameter is a String or Null

### DIFF
--- a/library/ZendService/Apple/Apns/Message.php
+++ b/library/ZendService/Apple/Apns/Message.php
@@ -228,8 +228,8 @@ class Message
      */
     public function setSound($sound)
     {
-        if (!is_scalar($sound)) {
-            throw new Exception\InvalidArgumentException('Sound must be a scalar value');
+        if ($sound !== null && !is_string($sound)) {
+            throw new Exception\InvalidArgumentException('Sound must be null or a string');
         }
         $this->sound = $sound;
 

--- a/tests/ZendService/Apple/Apns/MessageTest.php
+++ b/tests/ZendService/Apple/Apns/MessageTest.php
@@ -102,10 +102,16 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($sound, $this->message->getSound());
     }
 
-    public function testSetSoundThrowsExceptionOnNonString()
+    public function testSetSoundThrowsExceptionOnNonScalar()
     {
         $this->setExpectedException('InvalidArgumentException');
         $this->message->setSound(array());
+    }
+
+    public function testSetSoundThrowsExceptionOnNonString()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        $this->message->setSound(12345);
     }
 
     public function testSetCustomData()


### PR DESCRIPTION
This resolves issue #3 by checking if the sound parameter is a string or null.

Updated unit tests to have proper naming and added new unit test.
