### PR TITLE
Corrected length for unicode chars

### DIFF
--- a/library/ZendService/Apple/Apns/Message.php
+++ b/library/ZendService/Apple/Apns/Message.php
@@ -301,7 +301,7 @@ class Message
         // don't escape utf8 payloads unless json_encode does not exist.
         if (defined('JSON_UNESCAPED_UNICODE') && function_exists('mb_strlen')) {
             $payload = json_encode($payload, JSON_UNESCAPED_UNICODE);
-            $length = mb_strlen($payload, 'UTF-8');
+            $length = strlen($payload);
         } else {
             $payload = JsonEncoder::encode($payload);
             $length = strlen($payload);

--- a/library/ZendService/Apple/Apns/Response/Feedback.php
+++ b/library/ZendService/Apple/Apns/Response/Feedback.php
@@ -100,7 +100,7 @@ class Feedback
         $rawResponse = trim($rawResponse);
         $token = unpack('Ntime/nlength/H*token', $rawResponse);
         $this->setTime($token['time']);
-        $this->setToken(substr($token['token'], 0, $token['length']));
+        $this->setToken(substr($token['token'], 0, $token['length'] * 2));
 
         return $this;
     }


### PR DESCRIPTION
mb_strlen($str, 'UTF-8') returns wrong length for unicode payload, unicode messaged does not send. Fixed to strlen($str)