### PR TITLE
Fix composer autoload namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "license": "BSD-3-Clause",
     "autoload": {
         "psr-0": {
-            "ZendService": "library/"
+            "ZendService\\Apple\\Apns\\": "library/"
         }
     },
     "repositories": [


### PR DESCRIPTION
In order to avoid conflicts with multiple ZendService PSR-0 autoload.
