### PR TITLE
fix exceptions namespace

### DIFF
--- a/library/ZendService/Apple/Apns/Client/AbstractClient.php
+++ b/library/ZendService/Apple/Apns/Client/AbstractClient.php
@@ -10,7 +10,7 @@
 
 namespace ZendService\Apple\Apns\Client;
 
-use ZendService\Apple\Exception;
+use ZendService\Apple\Apns\Exception;
 
 /**
  * Apple Push Notification Abstract Client

--- a/library/ZendService/Apple/Apns/Client/Feedback.php
+++ b/library/ZendService/Apple/Apns/Client/Feedback.php
@@ -10,7 +10,7 @@
 
 namespace ZendService\Apple\Apns\Client;
 
-use ZendService\Apple\Exception;
+use ZendService\Apple\Apns\Exception;
 use ZendService\Apple\Apns\Response\Feedback as FeedbackResponse;
 
 /**

--- a/library/ZendService/Apple/Apns/Client/Message.php
+++ b/library/ZendService/Apple/Apns/Client/Message.php
@@ -12,7 +12,7 @@
 
 namespace ZendService\Apple\Apns\Client;
 
-use ZendService\Apple\Exception;
+use ZendService\Apple\Apns\Exception;
 use ZendService\Apple\Apns\Message as ApnsMessage;
 use ZendService\Apple\Apns\Response\Message as MessageResponse;
 

--- a/library/ZendService/Apple/Apns/Exception/InvalidArgumentException.php
+++ b/library/ZendService/Apple/Apns/Exception/InvalidArgumentException.php
@@ -8,9 +8,12 @@
  * @package   Zend_Service
  */
 
-namespace ZendService\Apple\Exception;
+namespace ZendService\Apple\Apns\Exception;
 
-class RuntimeException extends \RuntimeException
+/**
+ * Invalid Argument Exception
+ */
+class InvalidArgumentException extends \InvalidArgumentException
 {
 
 }

--- a/library/ZendService/Apple/Apns/Exception/RuntimeException.php
+++ b/library/ZendService/Apple/Apns/Exception/RuntimeException.php
@@ -8,12 +8,9 @@
  * @package   Zend_Service
  */
 
-namespace ZendService\Apple\Exception;
+namespace ZendService\Apple\Apns\Exception;
 
-/**
- * Invalid Argument Exception
- */
-class InvalidArgumentException extends \InvalidArgumentException
+class RuntimeException extends \RuntimeException
 {
 
 }

--- a/library/ZendService/Apple/Apns/Message.php
+++ b/library/ZendService/Apple/Apns/Message.php
@@ -10,7 +10,7 @@
 
 namespace ZendService\Apple\Apns;
 
-use ZendService\Apple\Exception;
+use ZendService\Apple\Apns\Exception;
 use Zend\Json\Encoder as JsonEncoder;
 
 /**

--- a/library/ZendService/Apple/Apns/Message/Alert.php
+++ b/library/ZendService/Apple/Apns/Message/Alert.php
@@ -10,7 +10,7 @@
 
 namespace ZendService\Apple\Apns\Message;
 
-use ZendService\Apple\Exception;
+use ZendService\Apple\Apns\Exception;
 
 /**
  * Message Alert Object

--- a/library/ZendService/Apple/Apns/Response/Feedback.php
+++ b/library/ZendService/Apple/Apns/Response/Feedback.php
@@ -10,7 +10,7 @@
 
 namespace ZendService\Apple\Apns\Response;
 
-use ZendService\Apple\Exception;
+use ZendService\Apple\Apns\Exception;
 
 /**
  * Feedback Response

--- a/library/ZendService/Apple/Apns/Response/Message.php
+++ b/library/ZendService/Apple/Apns/Response/Message.php
@@ -12,7 +12,7 @@
 
 namespace ZendService\Apple\Apns\Response;
 
-use ZendService\Apple\Exception;
+use ZendService\Apple\Apns\Exception;
 
 /**
  * Message Response


### PR DESCRIPTION
when loading the library with composer, the exceptions namespace is not included in the autoloading (see #14 as well), as the library include path only loads `ZendService\\Apple\\Apns\\`, and the exceptions are under `ZendService\\Apple``. 

``` php
PHP Fatal error:  Class 'ZendService\Apple\Exception\InvalidArgumentException' not found in /var/test/vendor/zendframework/zendservice-apple-apns/library/ZendService/Apple/Apns/Client/AbstractClient.php on line 66

Fatal error: Class 'ZendService\Apple\Exception\InvalidArgumentException' not found in /var/test/vendor/zendframework/zendservice-apple-apns/library/ZendService/Apple/Apns/Client/AbstractClient.php on line 66
```

the solution is either to adjust composor.json to include all the exception namespapce, or to move the exception classes into the correct namesapce.
