### PR TITLE
Add `Exception` namespace to autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "license": "BSD-3-Clause",
     "autoload": {
         "psr-0": {
-            "ZendService\\Apple\\Apns\\": "library/"
+            "ZendService\\Apple\\Apns\\": "library/",
+            "ZendService\\Apple\\Exception\\": "library/"
         }
     },
     "repositories": [


### PR DESCRIPTION
Add the `ZendService\Apple\Exception` namespace handler to the autoload
configuration. It is not under the `Apns` namespace that the existing
configuration handles.

This is the intermediary fix requested in the discussion for https://github.com/zendframework/ZendService_Apple_Apns/pull/16#issuecomment-48394672
