### PR TITLE
Prevent custom data payload sending empty aps key

### DIFF
--- a/library/ZendService/Apple/Apns/Message.php
+++ b/library/ZendService/Apple/Apns/Message.php
@@ -273,18 +273,21 @@ class Message
     public function getPayload()
     {
         $message = array();
-        $message['aps'] = array();
+        $aps = array();
         if ($this->alert && ($alert = $this->alert->getPayload())) {
-            $message['aps']['alert'] = $alert;
+            $aps['alert'] = $alert;
         }
         if (!is_null($this->badge)) {
-            $message['aps']['badge'] = $this->badge;
+            $aps['badge'] = $this->badge;
         }
         if (!is_null($this->sound)) {
-            $message['aps']['sound'] = $this->sound;
+            $aps['sound'] = $this->sound;
         }
         if (!empty($this->custom)) {
             $message = array_merge($this->custom, $message);
+        }
+        if (!empty($aps)) {
+            $message['aps'] = $aps;
         }
 
         return $message;

--- a/tests/ZendService/Apple/Apns/MessageTest.php
+++ b/tests/ZendService/Apple/Apns/MessageTest.php
@@ -192,4 +192,14 @@ class MessageTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals($this->message->getPayloadJson(), $result);
         }
     }
+
+    public function testCustomDataPayloadDoesNotIncludeEmptyApsData()
+    {
+        $data = array('custom' => 'data');
+        $this->message->setCustom($data);
+
+        $payload = $this->message->getPayload();
+        $this->assertEquals($payload, array('custom' => 'data'));
+    }
+
 }


### PR DESCRIPTION
When a Message with custom data payload is sent, without any data in the
`aps` data key, the empty array is encoded into the JSON. This can cause
problems on the receiving device.

The empty array is encoded as "[]" instead of an empty object "{}". This may also be fixed by forcing a cast to an object, but I see no evidence that this would be any better than removing the key entirely.

Note: This may also be a a bug in the library handling the push on the device, which I will investigate, but I see no harm in fixing it at this end also.
