### PR TITLE
Fix wrong feedback token length.

### DIFF
--- a/library/ZendService/Apple/Apns/Response/Feedback.php
+++ b/library/ZendService/Apple/Apns/Response/Feedback.php
@@ -100,7 +100,7 @@ class Feedback
         $rawResponse = trim($rawResponse);
         $token = unpack('Ntime/nlength/H*token', $rawResponse);
         $this->setTime($token['time']);
-        $this->setToken(substr($token['token'], 0, $token['length']));
+        $this->setToken(substr($token['token'], 0, $token['length'] * 2));
 
         return $this;
     }


### PR DESCRIPTION
This pull request is about to fix wrong feedback token length.


In real sandbox environment I get 32bit token from `feedback()`.

```
array (size=1)
  0 =>
    object(ZendService\Apple\Apns\Response\Feedback)[5]
        protected 'token' => string '8c73d887c40dc5e581a96cc379906b08' (length=32)
        protected 'time' => int 1420642410
```

So I add `var_dump()` in `ZendService\Apple\Apns\Response\Feedback`.

```php
public function parseRawResponse($rawResponse)
{
  $rawResponse = trim($rawResponse);
  $token = unpack('Ntime/nlength/H*token', $rawResponse);

  var_dump($token);

  $this->setTime($token['time']);
  $this->setToken(substr($token['token'], 0, $token['length']));

  return $this;
}
```

And I get this response.
```
array (size=3)
  'time' => int 1420642410
  'length' => int 32
  'token' => string '8c73d887c40dc5e581a96cc379906b0835c6d7f3d182e4f67b11d2db6e9ba947' (length=64)
```

After I read the [apple apns document](https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/CommunicatingWIthAPS.html), I found this.

| Type | description          |
| ------------- | ----------- |
| Timestamp | A timestamp (as a four-byte time_t value) indicating when APNs determined that the app no longer exists on the device. This value, which is in network order, represents the seconds since 12:00 midnight on January 1, 1970 UTC.          |
| Token length      | The length of the device token as a two-byte integer value in network order.|
| Device token     | The device token in binary format.   |

This length is for token in bytes, and 1 byte will comes 2 length of string in php, so this length should be multiply by 2.