### PR TITLE
Fix wrong feedback token length.

### DIFF
--- a/library/ZendService/Apple/Apns/Response/Feedback.php
+++ b/library/ZendService/Apple/Apns/Response/Feedback.php
@@ -100,7 +100,7 @@ class Feedback
         $rawResponse = trim($rawResponse);
         $token = unpack('Ntime/nlength/H*token', $rawResponse);
         $this->setTime($token['time']);
-        $this->setToken(substr($token['token'], 0, $token['length']));
+        $this->setToken(substr($token['token'], 0, $token['length'] * 2));
 
         return $this;
     }

--- a/tests/ZendService/Apple/Apns/FeedbackClientTest.php
+++ b/tests/ZendService/Apple/Apns/FeedbackClientTest.php
@@ -38,7 +38,7 @@ class FeedbackClientTest extends \PHPUnit_Framework_TestCase
         $this->setupValidBase();
         $time = time();
         $token = 'abc123';
-        $length = strlen($token);
+        $length = strlen($token) / 2;
         $this->apns->setReadResponse(pack('NnH*', $time, $length, $token));
         $response = $this->apns->feedback();
         $this->assertCount(1, $response);


### PR DESCRIPTION
According to apple apns document, here should be multiply by 2.