### PR TITLE
code completion

### DIFF
--- a/library/ZendService/Apple/Apns/Client/Message.php
+++ b/library/ZendService/Apple/Apns/Client/Message.php
@@ -37,8 +37,8 @@ class Message extends AbstractClient
     /**
      * Send Message
      *
-     * @param  ZendService\Apple\Apns\Message          $message
-     * @return ZendService\Apple\Apns\Response\Message
+     * @param  \ZendService\Apple\Apns\Message          $message
+     * @return \ZendService\Apple\Apns\Response\Message
      */
     public function send(ApnsMessage $message)
     {

--- a/library/ZendService/Apple/Apns/Client/Message.php
+++ b/library/ZendService/Apple/Apns/Client/Message.php
@@ -37,8 +37,8 @@ class Message extends AbstractClient
     /**
      * Send Message
      *
-     * @param  \ZendService\Apple\Apns\Message          $message
-     * @return \ZendService\Apple\Apns\Response\Message
+     * @param  ApnsMessage          $message
+     * @return MessageResponse
      */
     public function send(ApnsMessage $message)
     {


### PR DESCRIPTION
code completion thinks
ZendService\Apple\Apns\Client\ZendService\Apple\Apns\Message is the
namespace without the trailing slash