### PR TITLE
Force TLS instead of SSL

### DIFF
--- a/library/ZendService/Apple/Apns/Client/Feedback.php
+++ b/library/ZendService/Apple/Apns/Client/Feedback.php
@@ -23,8 +23,8 @@ class Feedback extends AbstractClient
      * @var array
      */
     protected $uris = array(
-        'ssl://feedback.sandbox.push.apple.com:2196',
-        'ssl://feedback.push.apple.com:2196'
+        'tls://feedback.sandbox.push.apple.com:2196',
+        'tls://feedback.push.apple.com:2196'
     );
 
     /**

--- a/library/ZendService/Apple/Apns/Client/Message.php
+++ b/library/ZendService/Apple/Apns/Client/Message.php
@@ -30,8 +30,8 @@ class Message extends AbstractClient
      * @var array
      */
     protected $uris = array(
-        'ssl://gateway.sandbox.push.apple.com:2195',
-        'ssl://gateway.push.apple.com:2195',
+        'tls://gateway.sandbox.push.apple.com:2195',
+        'tls://gateway.push.apple.com:2195',
     );
 
     /**


### PR DESCRIPTION
See https://developer.apple.com/news/?id=10222014a

Following this table: http://php.net/manual/en/migration56.openssl.php#migration56.openssl.crypto-method
SSL can be both SSL or TLS. But SSLv3 is disabled, only TLS can be used.