### PR TITLE
Fix apns response (http://php.net/manual/en/function.stream-get-meta-data.php#refsect1-function.stream-get-meta-data-returnvalues)

### DIFF
--- a/library/ZendService/Apple/Apns/Client/AbstractClient.php
+++ b/library/ZendService/Apple/Apns/Client/AbstractClient.php
@@ -146,15 +146,17 @@ abstract class AbstractClient
      * @param  int    $length
      * @return string
      */
-    protected function read($length = 1024)
+    protected function read($length = 6)
     {
         if (!$this->isConnected()) {
             throw new Exception\RuntimeException('You must open the connection prior to reading data');
         }
         $data = false;
-        $stream_meta_data = stream_get_meta_data($this->socket);
-        if ($stream_meta_data['unread_bytes'] > 0) {
-            $data = fread($this->socket, (int) $length);
+        $read = [$this->socket];
+        $null = null;
+
+        if (0 < @stream_select($read, $null, $null, 1, 0)) {
+            $data = @fread($this->socket, (int) $length);
         }
 
         return $data;


### PR DESCRIPTION
Hi,

I'm having a problem that can not get response for Apns.
Also code changed order to resolve also the following issues.

- Response for unread_bytes is always 0 is empty
- Deprecated unread_bytes is being used

Best regards.

P.S.

#35 will also be corresponding.

