### PR TITLE
Add safari push support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
             "ZendService\\Apple\\Exception\\": "library/"
         }
     },
+    "minimum-stability": "dev",
     "repositories": [
         {
             "type": "composer",
@@ -29,5 +30,5 @@
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"
-	}
+    }
 }

--- a/library/ZendService/Apple/Apns/Message.php
+++ b/library/ZendService/Apple/Apns/Message.php
@@ -66,6 +66,12 @@ class Message
      */
     protected $category;
 
+    /** 
+     * URL Arguments
+     * @var array|null
+     */
+    protected $urlArgs;
+
     /**
      * Custom Attributes
      * @var array|null
@@ -300,6 +306,29 @@ class Message
     }
 
     /**
+     * Get URL arguments
+     *
+     * @return array|null
+     */
+    public function getUrlArgs()
+    {
+        return $this->urlArgs;
+    }
+
+    /**
+     * Set URL arguments
+     *
+     * @param  array|null $urlArgs
+     * @return Message
+     */
+    public function setUrlArgs(array $urlArgs)
+    {
+        $this->urlArgs = $urlArgs;
+
+        return $this;
+    }
+
+    /**
      * Get Custom Data
      *
      * @return array|null
@@ -351,6 +380,9 @@ class Message
         }
         if (!is_null($this->category)) {
             $aps['category'] = $this->category;
+        }
+        if (!is_null($this->urlArgs)) {
+            $aps['url-args'] = $this->urlArgs;
         }
         if (!empty($this->custom)) {
             $message = array_merge($this->custom, $message);

--- a/tests/ZendService/Apple/Apns/MessageTest.php
+++ b/tests/ZendService/Apple/Apns/MessageTest.php
@@ -167,6 +167,13 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->message->setCategory(12345);
     }
 
+    public function testSetUrlArgsReturnsString()
+    {
+        $urlArgs = array('path/to/somewhere');
+        $this->message->setUrlArgs($urlArgs);
+        $this->assertEquals($urlArgs, $this->message->getUrlArgs());
+    }
+
     public function testSetCustomData()
     {
         $data = array('key' => 'val', 'key2' => array(1, 2, 3, 4, 5));


### PR DESCRIPTION
Added support for Apple Push Notifications.  Specifically, the `url-args` parameter is required as part of the `aps` dictionary.  See https://developer.apple.com/library/mac/documentation/NetworkingInternet/Conceptual/NotificationProgrammingGuideForWebsites/PushNotifications/PushNotifications.html