### PR TITLE
Always include 'aps' key

### DIFF
--- a/library/ZendService/Apple/Apns/Message.php
+++ b/library/ZendService/Apple/Apns/Message.php
@@ -389,9 +389,7 @@ class Message
         if (!empty($this->custom)) {
             $message = array_merge($this->custom, $message);
         }
-        if (!empty($aps)) {
-            $message['aps'] = $aps;
-        }
+        $message['aps'] = (object)$aps;
 
         return $message;
     }


### PR DESCRIPTION
In #18, a change was made to exclude the `aps` key if it is empty. This causes totally empty notifications to fail (for example, when [pushing to an Apple Wallet pass](https://developer.apple.com/library/content/documentation/UserExperience/Conceptual/PassKit_PG/Updating.html#//apple_ref/doc/uid/TP40012195-CH5-SW63) to trigger an update). The correct behavior to would be to include the empty `aps` key encoded as a JSON object, like this:

``` json
{
    "aps": {}
}
```

This PR fixes this by always including the `"aps"` key and casting `$aps` to an object, so that in the event it is empty it will be correctly encoded as an empty JSON object, rather that an empty JSON array as mentioned in #18.

[Reference](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/TheNotificationPayload.html):

> For each notification, compose a JSON dictionary object (as defined by RFC 4627). This dictionary **must contain another dictionary identified by the aps key**.
