### PR TITLE
mutable-content support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "notification",
         "apple"
     ],
-    "homepage": "http://packages.zendframework.com/",
+    "homepage": "https://packages.zendframework.com/",
     "license": "BSD-3-Clause",
     "autoload": {
         "psr-0": {
@@ -20,7 +20,7 @@
     "repositories": [
         {
             "type": "composer",
-            "url": "http://packages.zendframework.com/"
+            "url": "https://packages.zendframework.com/"
         }
     ],
     "require": {

--- a/library/ZendService/Apple/Apns/Message.php
+++ b/library/ZendService/Apple/Apns/Message.php
@@ -10,8 +10,8 @@
 
 namespace ZendService\Apple\Apns;
 
-use ZendService\Apple\Exception;
 use Zend\Json\Encoder as JsonEncoder;
+use ZendService\Apple\Exception;
 
 /**
  * APNs Message
@@ -58,7 +58,7 @@ class Message
      * Mutable Content
      * @var int|null
      */
-    protected $mutableContent;
+    private $mutableContent;
 
     /**
      * Content Available
@@ -262,25 +262,17 @@ class Message
     }
 
     /**
-     * Get Mutable Content
-     * 
-     * @return int|null
-     */
-    public function getMutableContent()
-    {
-        return $this->mutableContent;
-    }
-
-    /**
      * Set Mutable Content
-     * 
+     *
      * @param int|null $value
      * @returns Message
      */
     public function setMutableContent($value)
     {
         if ($value !== null && !is_int($value)) {
-            throw new Exception\InvalidArgumentException('Mutable Content must be null or an integer');
+            throw new Exception\InvalidArgumentException(
+                'Mutable Content must be null or an integer, received: ' . gettype($value)
+            );
         }
         $this->mutableContent = $value;
 

--- a/library/ZendService/Apple/Apns/Message.php
+++ b/library/ZendService/Apple/Apns/Message.php
@@ -55,6 +55,12 @@ class Message
     protected $sound;
 
     /**
+     * Mutable Content
+     * @var int|null
+     */
+    protected $mutableContent;
+
+    /**
      * Content Available
      * @var int|null
      */
@@ -256,6 +262,32 @@ class Message
     }
 
     /**
+     * Get Mutable Content
+     * 
+     * @return int|null
+     */
+    public function getMutableContent()
+    {
+        return $this->mutableContent;
+    }
+
+    /**
+     * Set Mutable Content
+     * 
+     * @param int|null $value
+     * @returns Message
+     */
+    public function setMutableContent($value)
+    {
+        if ($value !== null && !is_int($value)) {
+            throw new Exception\InvalidArgumentException('Mutable Content must be null or an integer');
+        }
+        $this->mutableContent = $value;
+
+        return $this;
+    }
+
+    /**
      * Get Content Available
      *
      * @return int|null
@@ -268,7 +300,7 @@ class Message
     /**
      * Set Content Available
      *
-     * @param  int|null $sound
+     * @param  int|null $value
      * @return Message
      */
     public function setContentAvailable($value)
@@ -376,6 +408,9 @@ class Message
         }
         if (!is_null($this->sound)) {
             $aps['sound'] = $this->sound;
+        }
+        if (!is_null($this->mutableContent)) {
+            $aps['mutable-content'] = $this->mutableContent;
         }
         if (!is_null($this->contentAvailable)) {
             $aps['content-available'] = $this->contentAvailable;

--- a/library/ZendService/Apple/Apns/Message.php
+++ b/library/ZendService/Apple/Apns/Message.php
@@ -274,6 +274,11 @@ class Message
                 'Mutable Content must be null or an integer, received: ' . gettype($value)
             );
         }
+
+        if (is_int($value) && $value !== 1) {
+            throw new Exception\InvalidArgumentException('Mutable Content supports only 1 as integer value');
+        }
+
         $this->mutableContent = $value;
 
         return $this;

--- a/tests/ZendService/Apple/Apns/MessageTest.php
+++ b/tests/ZendService/Apple/Apns/MessageTest.php
@@ -144,22 +144,28 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     public function provideSetMutableContentThrowsExceptionOnNonIntegerOneOrNullData()
     {
         return array(
-            'unsupported integer value' => array(
+            'unsupported positive integer' => array(
                 'value' => 2,
             ),
-            'boolean'                   => array(
+            'zero integer'                 => array(
+                'value' => 0,
+            ),
+            'negative integer'             => array(
+                'value' => -1,
+            ),
+            'boolean'                      => array(
                 'value' => true,
             ),
-            'string'                    => array(
+            'string'                       => array(
                 'value' => 'any string',
             ),
-            'float'                     => array(
+            'float'                        => array(
                 'value' => 123.12,
             ),
-            'array'                     => array(
+            'array'                        => array(
                 'value' => array(),
             ),
-            'object'                    => array(
+            'object'                       => array(
                 'value' => new \stdClass(),
             ),
         );

--- a/tests/ZendService/Apple/Apns/MessageTest.php
+++ b/tests/ZendService/Apple/Apns/MessageTest.php
@@ -128,11 +128,11 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider provideSetMutableContentThrowsExceptionOnNonIntegerOrNullData
+     * @dataProvider provideSetMutableContentThrowsExceptionOnNonIntegerOneOrNullData
      *
      * @param mixed $value
      */
-    public function testSetMutableContentThrowsExceptionOnNonIntegerAndNull($value)
+    public function testSetMutableContentThrowsExceptionOnNonIntegerOneAndNull($value)
     {
         $this->setExpectedException('InvalidArgumentException');
         $this->message->setMutableContent($value);
@@ -141,22 +141,25 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     /**
      * @return array
      */
-    public function provideSetMutableContentThrowsExceptionOnNonIntegerOrNullData()
+    public function provideSetMutableContentThrowsExceptionOnNonIntegerOneOrNullData()
     {
         return array(
-            'boolean' => array(
+            'unsupported integer value' => array(
+                'value' => 2,
+            ),
+            'boolean'                   => array(
                 'value' => true,
             ),
-            'string'  => array(
+            'string'                    => array(
                 'value' => 'any string',
             ),
-            'float'   => array(
+            'float'                     => array(
                 'value' => 123.12,
             ),
-            'array'   => array(
+            'array'                     => array(
                 'value' => array(),
             ),
-            'object'  => array(
+            'object'                    => array(
                 'value' => new \stdClass(),
             ),
         );

--- a/tests/ZendService/Apple/Apns/MessageTest.php
+++ b/tests/ZendService/Apple/Apns/MessageTest.php
@@ -10,9 +10,9 @@
 
 namespace ZendServiceTest\Apple\Apns\TestAsset;
 
+use Zend\Json\Encoder as JsonEncoder;
 use ZendService\Apple\Apns\Message;
 use ZendService\Apple\Apns\Message\Alert;
-use Zend\Json\Encoder as JsonEncoder;
 
 /**
  * @category   ZendService
@@ -63,13 +63,13 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('InvalidArgumentException');
         $this->alert->setLaunchImage(array());
     }
-    
+
     public function testSetAlertThrowsExceptionOnTitleNonString()
     {
         $this->setExpectedException('InvalidArgumentException');
         $this->alert->setTitle(array());
     }
-    
+
     public function testSetAlertThrowsExceptionOnTitleLocKeyNonString()
     {
         $this->setExpectedException('InvalidArgumentException');
@@ -127,25 +127,54 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->message->setSound(12345);
     }
 
-    public function testSetMutableContentThrowsExceptionOnNonInteger()
+    /**
+     * @dataProvider provideSetMutableContentThrowsExceptionOnNonIntegerOrNullData
+     *
+     * @param mixed $value
+     */
+    public function testSetMutableContentThrowsExceptionOnNonIntegerAndNull($value)
     {
         $this->setExpectedException('InvalidArgumentException');
-        $this->message->setMutableContent("string");
-    }
-
-    public function testGetMutableContentReturnsCorrectInteger()
-    {
-        $value = 1;
         $this->message->setMutableContent($value);
-        $this->assertEquals($value, $this->message->getMutableContent());
     }
 
-    public function testSetMutableContentResultsInCorrectPayload()
+    /**
+     * @return array
+     */
+    public function provideSetMutableContentThrowsExceptionOnNonIntegerOrNullData()
+    {
+        return array(
+            'boolean' => array(
+                'value' => true,
+            ),
+            'string'  => array(
+                'value' => 'any string',
+            ),
+            'float'   => array(
+                'value' => 123.12,
+            ),
+            'array'   => array(
+                'value' => array(),
+            ),
+            'object'  => array(
+                'value' => new \stdClass(),
+            ),
+        );
+    }
+
+    public function testSetMutableContentResultsInCorrectPayloadWithIntegerValue()
     {
         $value = 1;
         $this->message->setMutableContent($value);
         $payload = $this->message->getPayload();
         $this->assertEquals($value, $payload['aps']['mutable-content']);
+    }
+
+    public function testSetMutableContentResultsInCorrectPayloadWithNullValue()
+    {
+        $this->message->setMutableContent(null);
+        $payload = $this->message->getPayload();
+        $this->assertFalse(isset($payload['aps']['mutable-content']));
     }
 
     public function testSetContentAvailableThrowsExceptionOnNonInteger()

--- a/tests/ZendService/Apple/Apns/MessageTest.php
+++ b/tests/ZendService/Apple/Apns/MessageTest.php
@@ -127,6 +127,27 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->message->setSound(12345);
     }
 
+    public function testSetMutableContentThrowsExceptionOnNonInteger()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        $this->message->setMutableContent("string");
+    }
+
+    public function testGetMutableContentReturnsCorrectInteger()
+    {
+        $value = 1;
+        $this->message->setMutableContent($value);
+        $this->assertEquals($value, $this->message->getMutableContent());
+    }
+
+    public function testSetMutableContentResultsInCorrectPayload()
+    {
+        $value = 1;
+        $this->message->setMutableContent($value);
+        $payload = $this->message->getPayload();
+        $this->assertEquals($value, $payload['aps']['mutable-content']);
+    }
+
     public function testSetContentAvailableThrowsExceptionOnNonInteger()
     {
         $this->setExpectedException('InvalidArgumentException');


### PR DESCRIPTION
Per https://developer.apple.com/reference/usernotifications/unnotificationserviceextension

Apple introduced new field `mutable-content` with the release of iOS 10. This field is designated for iOS notification extensions that allow download of additional information.