### PR TITLE
Update AbstractClient.php

### DIFF
--- a/library/ZendService/Apple/Apns/Client/AbstractClient.php
+++ b/library/ZendService/Apple/Apns/Client/AbstractClient.php
@@ -56,7 +56,7 @@ abstract class AbstractClient
     public function open($environment, $certificate, $passPhrase = null)
     {
         if ($this->isConnected) {
-            throw new Exception\RuntimeException('Connection has already been opened and must be closed');
+            return true;
         }
 
         if (!array_key_exists($environment, $this->uris)) {


### PR DESCRIPTION
Send multiple token for the first time when send a notification, there was a token error, the connection will not shut down.
Then continue to send a notification, it will throw exceptions( Connection has already been opened and must be closed ), cannot continue to send.
I don't think it is reasonable.