### PR TITLE
Added capital letters to token validation

### DIFF
--- a/library/ZendService/Apple/Apns/Message.php
+++ b/library/ZendService/Apple/Apns/Message.php
@@ -129,10 +129,10 @@ class Message
             ));
         }
 
-        if (preg_match('/[^0-9a-fA-F]/', $token)) {
+        if (preg_match('/[^0-9a-f]/i', $token)) {
             throw new Exception\InvalidArgumentException(sprintf(
                     'Device token must be mask "%s". Token given: "%s"',
-                    '/[^0-9a-fA-F]/',
+                    '/[^0-9a-f]/i',
                     $token
             ));
         }

--- a/library/ZendService/Apple/Apns/Message.php
+++ b/library/ZendService/Apple/Apns/Message.php
@@ -129,10 +129,10 @@ class Message
             ));
         }
 
-        if (preg_match('/[^0-9a-f]/', $token)) {
+        if (preg_match('/[^0-9a-fA-F]/', $token)) {
             throw new Exception\InvalidArgumentException(sprintf(
                     'Device token must be mask "%s". Token given: "%s"',
-                    '/[^0-9a-f]/',
+                    '/[^0-9a-fA-F]/',
                     $token
             ));
         }


### PR DESCRIPTION
I moved the forked repository, and thus was unable to update PR #44.

Herby the requested update.

---

Push notifications for Mac through Safari returns a device token with capital letters. The setToken method does now accept capital letters as well.