### PR TITLE
Restore error handler when exception is thrown

### DIFF
--- a/library/ZendService/Apple/Apns/Client/AbstractClient.php
+++ b/library/ZendService/Apple/Apns/Client/AbstractClient.php
@@ -109,6 +109,7 @@ abstract class AbstractClient
                 )
             );
         } catch (StreamSocketClientException $e) {
+            restore_error_handler();
             throw new Exception\RuntimeException(sprintf(
                 'Unable to connect: %s: %d (%s)',
                 $host,


### PR DESCRIPTION
I consider it slightly impolite to steal the error handler and not give it back.