### PR TITLE
Explicitly use TLS version 1.2

### DIFF
--- a/src/Apns/Client/Message.php
+++ b/src/Apns/Client/Message.php
@@ -30,8 +30,8 @@ class Message extends AbstractClient
      * @var array
      */
     protected $uris = [
-        'tls://gateway.sandbox.push.apple.com:2195',
-        'tls://gateway.push.apple.com:2195',
+        'tlsv1.2://gateway.sandbox.push.apple.com:2195',
+        'tlsv1.2://gateway.push.apple.com:2195',
     ];
 
     /**


### PR DESCRIPTION
APNS is suddenly rejecting our connection with the following message:

`Unable to connect: tls://gateway.push.apple.com:2195: 2 (stream_socket_client(): SSL operation failed with code 1. OpenSSL Error messages: error:1409442E:SSL routines:ssl3_read_bytes:tlsv1 alert protocol version)`

Changing "tls://gateway.push.apple.com:2195" to "tlsv1.2://gateway.push.apple.com:2195" apparently solves this issue.