### PR TITLE
Added support for apns response error code 10 (shutdown)

### DIFF
--- a/src/Apns/Response/Message.php
+++ b/src/Apns/Response/Message.php
@@ -83,10 +83,10 @@ class Message
      */
     public function setCode($code)
     {
-		if (($code < 0 || $code > 8) && $code != 10 && $code != 255) {
-			throw new Exception\InvalidArgumentException('Code must be between 0-8, 10 OR 255');
-		}
-        
+        if (($code < 0 || $code > 8) && $code != 10 && $code != 255) {
+            throw new Exception\InvalidArgumentException('Code must be between 0-8, 10 OR 255');
+        }
+
 
         $this->code = $code;
 

--- a/src/Apns/Response/Message.php
+++ b/src/Apns/Response/Message.php
@@ -36,6 +36,8 @@ class Message
     const RESULT_INVALID_TOPIC_SIZE = 6;
     const RESULT_INVALID_PAYLOAD_SIZE = 7;
     const RESULT_INVALID_TOKEN = 8;
+    const RESULT_INVALID_SHUTDOWN = 10;
+
     const RESULT_UNKNOWN_ERROR = 255;
 
     /**
@@ -81,9 +83,11 @@ class Message
      */
     public function setCode($code)
     {
-        if (($code < 0 || $code > 8) && $code != 255) {
-            throw new Exception\InvalidArgumentException('Code must be between 0-8 OR 255');
-        }
+		if (($code < 0 || $code > 8) && $code != 10 && $code != 255) {
+			throw new Exception\InvalidArgumentException('Code must be between 0-8, 10 OR 255');
+		}
+        
+
         $this->code = $code;
 
         return $this;


### PR DESCRIPTION
We got the Apple apns server response code 10 (which means server shutdown) from time to time in the past.
This error code is currently not supported by the Message class of the ZendService_Apple_Apns package. 
I created a patch in order to support the code in the future.
Please refer to 
https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/BinaryProviderAPI.html 
for more details on the error response code 10.